### PR TITLE
Minor Grammatical Fix/Improvement

### DIFF
--- a/tos.md
+++ b/tos.md
@@ -4,7 +4,7 @@ By using Sned, directly or indirectly, the user agrees to the following points.
 ## DEFINITIONS
 - "Users" refers to any individual that directly utilizes Sned. Either via command interaction with Sned through Discord, and/or any form of communication whereas the user talks/texts to the Sned bot.
 
-- "Us/We/Our" refers to the team behind Sned. The team is currently comprised of one member (hypergonial) who programs the bot, aids users with support and help in regards to Sned.
+- "Us/We/Our" refers to the team behind Sned. The team is currently composed of one member (hypergonial) who programs the bot, aids users with support and help in regards to Sned.
 
 - "Data" refers to any user entered information provided to Sned. This information includes data such as timezones, reminders, tags, moderation journals, Discord user information, and other public data.
 


### PR DESCRIPTION
### Grammatical Improvement
I have altered the documentation by altering the ungrammatical phrase 'comprised of'.

#### Description
All usages of 'comprised of' have been replaced with more suitable alternatives: 'comprises', 'composed of', 'including', ....

#### Justification
[Comprise or Compose? - Grammar Monster](https://www.grammar-monster.com/easily_confused/comprise_compose.htm)